### PR TITLE
delete all info of one user who wants to withdraw

### DIFF
--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -83,14 +83,21 @@ exports.deleteUsers = async function (req, res) {
     */
     const userIdx = req.params.userIdx;
 
-    if(!userIdx) //userIdx == "undefined"
+    if(!userIdx){
         return res.send(errResponse(baseResponse.USER_USERIDX_EMPTY));
+    }else if(userIdx <= 0){
+        return res.send(errResponse(baseResponse.USER_USERIDX_LENGTH));
+    }
 
-    const withdrawalResponse = await userService.deleteUserInfo(userIdx);
-    return res.send(response(baseResponse.SUCCESS, withdrawalResponse));
+    const userIdxResult = await userService.deleteUserInfo(userIdx);
+    return res.send(response(baseResponse.SUCCESS, userIdxResult));
 }
 
-
+/**
+ * API No. 1.5
+ * API Name : 비밀번호 변경 API
+ * [PATCH] /users
+ */
 
 
 /**

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -54,6 +54,70 @@ async function selectUserAccount(connection, email) {
   return selectUserAccountRow[0];
 }
 
+// 유저 관련 데이터 삭제(ReadingRecord / FlowerPot / UserFlowerList / User 순서로 삭제)
+//성공 쿼리 - 유저 삭제 1. readingRecord 삭제
+async function deleteUserRRInfo(connection, userIdx) {
+  const deleteReadingRecordQuery = `
+    DELETE rr.*
+    FROM FlowerPot as fp
+    left join ReadingRecord as rr on rr.flowerPotIdx = fp.idx
+    WHERE fp.userIdx=?;
+  `;
+
+  const deleteReadingRecordRow = await connection.query(
+    deleteReadingRecordQuery,
+    userIdx
+  );
+  return deleteReadingRecordRow[0];
+}
+//성공 쿼리 - 유저 삭제 2. 화분
+async function deleteUserFPInfo(connection, userIdx) {
+  const deleteFlowerPotQuery = `
+    DELETE fp.*
+    FROM FlowerPot as fp
+    WHERE fp.userIdx=?;
+  `;
+
+  const deleteFPQueryRow = await connection.query(
+    deleteFlowerPotQuery,
+    userIdx
+  );
+  
+  return deleteFPQueryRow[0];
+}
+
+//성공 쿼리 - 3. 유저플라워리스트
+async function deleteUserUFLInfo(connection, userIdx) {
+  const deleteUFLQuery = `
+    DELETE ufl.*
+    FROM UserFlowerList as ufl
+    WHERE ufl.userIdx=?;
+  `;
+
+  const deleteUFLQueryRow = await connection.query(
+    deleteUFLQuery,
+    userIdx
+  );
+
+  return deleteUFLQueryRow[0];
+}
+
+//성공 쿼리 - 4. 유저테이블
+async function deleteUserUInfo(connection, userIdx) {
+  const deleteUQuery = `
+    DELETE u.*
+    FROM User as u
+    WHERE u.idx=?;
+  `;
+
+  const deleteUQueryRow = await connection.query(
+    deleteUQuery,
+    userIdx
+  );
+
+  return deleteUQueryRow[0];
+}
+
 // // 유저 탈퇴 시 존재하는 유저인지 확인()
 // async function IsItActiveUser(connection, userIdx) {
 //   const IsItActiveUserQuery = `
@@ -64,24 +128,6 @@ async function selectUserAccount(connection, email) {
 //   const [IsItActiveUserRows] = await connection.query(IsItActiveUserQuery, userIdx);
 //   return IsItActiveUserRows;
 // }
-
-//유저 및 관련 데이터(화분, 독서기록, 화분획득여부) 삭제
-async function deleteUser(connection, userIdx) {
-  //UserFlowerList 삭제 쿼리
-
-  //독서 기록 삭제 쿼리(이미 존재하면 다른 파일에서 가져오기)
-
-  //화분 삭제 쿼리(이미 존재하면 다른 파일에서 가져오기)
-
-  const deleteUserInfoQuery = `
-  DELETE u.*
-    FROM User as u
-  WHERE u.idx=?; 
-    `;
-  const [deleteUserInfoRow] = await connection.query(deleteUserInfoQuery, userIdx);
-  return deleteUserInfoRow;
-}
-
 
 // 카카오계정 이메일이 존재하는지 확인
 async function kakaoUserAccountCheck(connection, email, type) {
@@ -183,30 +229,21 @@ async function findPassword(connection, findPasswordParams) {
 
 }
 
- // 초기 화분 획득
-    
- async function acquireFlowerpot(connection, createdUserIdx) {
-  const acquireFlowerpotQuery = `
-  INSERT INTO  UserFlowerList(userIdx,flowerDataIdx)
-  VALUES (?,3)
-  `;
-  const [acquireFlowerpotRow] = await connection.query(acquireFlowerpotQuery,createdUserIdx);
-  return acquireFlowerpotRow;
-}
-
-
 
   module.exports = {
     selectUserEmail,
     insertUserInfo,
     selectUserPassword,
     selectUserAccount,
-    deleteUser,
+    // deleteUserRR,
+    deleteUserRRInfo,
+    deleteUserFPInfo,
+    deleteUserUFLInfo,
+    deleteUserUInfo,
     kakaoUserAccountCheck,
     kakaoUserAccountInsert,
     kakaoUserAccountInfo,
     getUserProfile,
     editUserIntroduction,
     findPassword,
-    acquireFlowerpot
   };

--- a/src/app/User/userRoute.js
+++ b/src/app/User/userRoute.js
@@ -7,10 +7,10 @@ module.exports = function(app){
     app.post('/users', user.postUsers);
 
     // 1.4 유저 탈퇴 API
-    app.delete('/users/:userIdx', user.deleteUsers);
+    app.delete('/users/userDelete/:userIdx', user.deleteUsers);
 
-    // // 1.5 자기소개 수정 API
-    // app.patch('/users/introduction', user.patchUserIntroduction);
+    // // 1.5 비밀번호 변경 API
+    // app.patch('/users/password/change', jwtMiddleware, user.changePassword);
 
     // // TODO: After 로그인 인증 방법 (JWT)
     // // 로그인 하기 API (JWT 생성)

--- a/src/app/User/userService.js
+++ b/src/app/User/userService.js
@@ -62,22 +62,45 @@ API Name: 유저 삭제 API
 exports.deleteUserInfo = async function (userIdx) {
     const connection = await pool.getConnection(async (conn) => conn);
     try {
-        const withdrawalResponse = await userDao.deleteUser(connection, userIdx);
-        return response(baseResponse.SUCCESS);
 
+        const deleteUserRRInfoResult = await userDao.deleteUserRRInfo(connection, userIdx);
+        // console.log('SUCCESS. You deleted 1. ReadingRecord.');
+        const deleteUserFPInfoResult = await userDao.deleteUserFPInfo(connection, userIdx);
+        // console.log('SUCCESS. You deleted 2. FlowerPot.');
+        const deleteUserUFLInfoResult = await userDao.deleteUserUFLInfo(connection, userIdx);
+        // console.log('SUCCESS. You deleted 3. UserFlowerList.');
+        const deleteUserUInfoResult = await userDao.deleteUserUInfo(connection, userIdx);
+        // console.log('SUCCESS. You deleted 4. User.');
+
+        return response(baseResponse.SUCCESS, { 'deletedUserIdx': userIdx });
         // // validation 이미 탈퇴한 유저일 때
         // const IsItActiveUserList = await userDao.IsItActiveUser(connection, userIdx);
         // if(IsItActiveUserList.length < 1 || IsItActiveUserList[0].status == 'DELETED'){
-        //     connection /*여기서부터 나중에*/
+        //     connection.release();
+        //     return errResponse(baseResponse.USER_NOT_EXIST);
         // }
+
+
+        // const deleteUsersList = await userDao.deleteUserRR(connection, userIdx);
+        // // const deleteUserFPList = await userDao.deleteUserFPInfoRow(connection, userIdx);
+        // // const deleteUserUFLList = await userDao.deleteUserUFLInfoRow(connection, userIdx);
+        // // const deleteUserUList = await userDao.deleteUserUInfoRow(connection, userIdx);
+
+        // console.log(deleteUsersList);
+        // return response(baseResponse.SUCCESS);
+        //     // deleteUserFPList,
+        //     // deleteUserUFLList,
+        //     // deleteUserUList
+           
+
+
     } catch (err) {
         console.log(`App - deleteUserInfo Service error\n: ${err.message}`);
         return errResponse(baseResponse.DB_ERROR);
     } finally {
         connection.release();
     }
-};
-
+}
 
 
 exports.kakaoLogin = async function (kakaoResult) {


### PR DESCRIPTION
I made a API for withdrawal. This makes every information of a user who wants to withdraw from Librog deleted. You can check that all of the information in the ReadingRecord/FlowerPot/UserFlowerList/User table will be deleted.
유저 삭제(탈퇴) API입니다. 탈퇴하고자 하는 유저의 모든 정보를 삭제합니다. 즉, 독서기록/화분/유저플라워리스트/유저 테이블(총 4개의 테이블)에 저장된 탈퇴 희망 유저의 정보를 삭제합니다.