### PR TITLE
add salt option &change hashing pattern-API 1.22

### DIFF
--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -335,8 +335,12 @@ exports.editIntroduce = async function (req, res) {
         }    
 
     const newPassword = getNewPassword();
+    
+    //salt
+    const gottensalt = await userService.getSalt(email);
 
-    const hashed = crypto.createHash('sha512').update(newPassword).digest('hex');
+    //newPassword+salt=>암호화
+    const hashed = crypto.pbkdf2Sync(newPassword, gottensalt.result, 1, 64, 'sha512').toString('hex');
     
     const findPasswordParams = [hashed, email];
     const findPasswordResult = await userService.findPassword(findPasswordParams);

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -55,6 +55,19 @@ async function selectUserSalt(connection, email) {
   return selectUserSaltRow;
 }
 
+//salt 체크 for 임시비번설정
+async function selectOnlySalt(connection, email) {
+  const selectOnlySaltQuery = `
+        SELECT salt
+        FROM User
+        WHERE email = ?`;
+  const selectOnlySaltRow = await connection.query(
+    selectOnlySaltQuery,
+      email
+  );
+  return selectOnlySaltRow[0];
+}
+
 // 유저 계정 상태 체크 (jwt 생성 위해 idx 값도 가져온다.)
 async function selectUserAccount(connection, email) {
   const selectUserAccountQuery = `
@@ -393,6 +406,7 @@ async function getProfileImgUrl(connection, idx) {
     insertUserInfo,
     selectUserPassword,
     selectUserSalt,
+    selectOnlySalt,
     selectUserAccount,
     deleteUserRRInfo,
     deleteUserFPInfo,

--- a/src/app/User/userService.js
+++ b/src/app/User/userService.js
@@ -243,6 +243,22 @@ exports.editIntroduce = async function(patchIntroductionParams) {
     }
 }
 
+exports.getSalt = async function(email) {
+    const connection = await pool.getConnection(async (conn) => conn);
+
+    try {
+        const saltRows = await userDao.selectOnlySalt(connection, email);
+        console.log('Service- saltRows[0].salt: ', saltRows[0].salt);
+        const resultObj = saltRows[0].salt;
+        return response(baseResponse.SUCCESS, resultObj);
+    } catch (err) {
+        logger.error(`App - getSalt Service error\n: ${err.message}`);
+        return errResponse(baseResponse.DB_ERROR);
+    } finally {
+        connection.release();
+    }
+}
+
 exports.findPassword = async function (findPasswordParams) {
     const connection = await pool.getConnection(async (conn) => conn);
     try {


### PR DESCRIPTION
To resolve the error that cannot login with temporary password which was issued through email, I added some salt option to API 1.22 and changed the hassing option which is same as API 2.1.
이메일로 발급된 임시비밀번호로 로그인이 불가능한 에러를 해결하기 위해 1.22 API에 salt옵션 관련 내용을 추가하고 로그인API와 동일한 hassing 패턴을 사용하도록 코드를 수정했습니다.