### PR TITLE
records - author length change from 45 to 100

### DIFF
--- a/config/baseResponseStatus.js
+++ b/config/baseResponseStatus.js
@@ -36,7 +36,7 @@ module.exports = {
     RECORDS_CONTENT_LENGTH : { "isSuccess": false, "code": 2031, "message":"content는 10000자보다 짧게 입력해주세요." },
 
     
-    RECORDS_AUTHOR_LENGTH : { "isSuccess": false, "code": 2033, "message":"author값은 45자보다 짧게 입력해주세요." },
+    RECORDS_AUTHOR_LENGTH : { "isSuccess": false, "code": 2033, "message":"author값은 100자보다 짧게 입력해주세요." },
     RECORDS_PUBLISHER_LENGTH : { "isSuccess": false, "code": 2035, "message":"publisher값은 45자보다 짧게 입력해주세요." },
     RECORDS_PUBLISHED_DATE_LENGTH : { "isSuccess": false, "code": 2037, "message":"publishedDate값은 45자보다 짧게 입력해주세요." },
 

--- a/src/app/Record/recordController.js
+++ b/src/app/Record/recordController.js
@@ -69,7 +69,7 @@ exports.postRecords = async function(req, res){
     }
     // 저자 arr 요소 하나씩 validation
     authorArr.forEach((author) => {
-        if(author.length > 45){
+        if(author.length > 100){
             return res.send(errResponse(baseResponse.RECORDS_AUTHOR_LENGTH));
         }
     });


### PR DESCRIPTION
I mediated the length limit value of the length of 'author' in 'Book' table from 45 to 100.
북테이블의 저자 항목에 대한 길이 제한을 45자에서 100자로 조정했습니다.